### PR TITLE
Update README to clarify fake backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A mobile app with voice commands and widget controls to open/close a MyQ garage 
 
 ## Backend API
 
+This demo backend stores garage door state in an in-memory dictionary and does
+not communicate with the official MyQ service or any real hardware.
+
 The FastAPI backend provides the following endpoints:
 
 - `POST /login` - Authenticate user


### PR DESCRIPTION
## Summary
- document that the backend is an in-memory demo and doesn't talk to MyQ hardware or services

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687624a2935083288e8e04fa0f1d19f3