### PR TITLE
Change status endpoint to POST

### DIFF
--- a/MyQGarageApp/App.tsx
+++ b/MyQGarageApp/App.tsx
@@ -214,14 +214,13 @@ export default function App() {
 
   const updateGarageStatus = async (creds: Credentials) => {
     try {
-      const params = new URLSearchParams({
-        email: creds.email,
-        password: creds.password,
-      });
-      const response = await fetch(`${API_BASE_URL}/status?${params}`, {
+      const response = await fetch(`${API_BASE_URL}/status`, {
+        method: 'POST',
         headers: {
+          'Content-Type': 'application/json',
           'Authorization': PROXY_AUTH,
         },
+        body: JSON.stringify(creds),
       });
       const data = await response.json();
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ The FastAPI backend provides the following endpoints:
 
 - `POST /login` - Authenticate user
 - `POST /open` - Open garage door
-- `POST /close` - Close garage door  
-- `GET /status` - Get current garage door status
+- `POST /close` - Close garage door
+- `POST /status` - Get current garage door status
+  (send JSON `{ "email": ..., "password": ... }`)
 
 ## Setup
 

--- a/main.py
+++ b/main.py
@@ -57,7 +57,7 @@ async def close_garage(request: LoginRequest):
     fake_db["user"]["garage_status"] = "closed"
     return CommandResponse(status="success", message="Garage door closed.")
 
-@app.get("/status", response_model=StatusResponse)
-async def get_status(email: str, password: str):
-    authenticate_user(email, password)
+@app.post("/status", response_model=StatusResponse)
+async def get_status(request: LoginRequest):
+    authenticate_user(request.email, request.password)
     return StatusResponse(garage_status=fake_db["user"]["garage_status"])


### PR DESCRIPTION
## Summary
- expose `/status` as POST instead of GET
- send credentials in the React Native app via JSON
- document new POST `/status` endpoint

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687624a11f0c8328844e6a87a89408d3