### PR TITLE
Add pytest-based FastAPI tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,6 @@ uvicorn = {extras = ["standard"], version = "^0.34.3"}
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn[standard]
+pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from main import app
+
+client = TestClient(app)
+
+LOGIN_DATA = {"email": "test@example.com", "password": "supersecret"}
+
+
+def test_login_success():
+    response = client.post("/login", json=LOGIN_DATA)
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "success",
+        "message": "Logged in successfully."
+    }
+
+
+def test_open_and_close_garage():
+    response = client.post("/open", json=LOGIN_DATA)
+    assert response.status_code == 200
+    assert response.json()["message"] == "Garage door opened."
+
+    status_resp = client.get("/status", params=LOGIN_DATA)
+    assert status_resp.status_code == 200
+    assert status_resp.json()["garage_status"] == "open"
+
+    response = client.post("/close", json=LOGIN_DATA)
+    assert response.status_code == 200
+    assert response.json()["message"] == "Garage door closed."
+
+    status_resp = client.get("/status", params=LOGIN_DATA)
+    assert status_resp.status_code == 200
+    assert status_resp.json()["garage_status"] == "closed"
+
+
+def test_retrieve_status():
+    status_resp = client.get("/status", params=LOGIN_DATA)
+    assert status_resp.status_code == 200
+    assert status_resp.json()["garage_status"] in {"open", "closed"}
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-import pytest
 from fastapi.testclient import TestClient
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -26,7 +25,7 @@ def test_open_and_close_garage():
     assert response.status_code == 200
     assert response.json()["message"] == "Garage door opened."
 
-    status_resp = client.get("/status", params=LOGIN_DATA)
+    status_resp = client.post("/status", json=LOGIN_DATA)
     assert status_resp.status_code == 200
     assert status_resp.json()["garage_status"] == "open"
 
@@ -34,13 +33,12 @@ def test_open_and_close_garage():
     assert response.status_code == 200
     assert response.json()["message"] == "Garage door closed."
 
-    status_resp = client.get("/status", params=LOGIN_DATA)
+    status_resp = client.post("/status", json=LOGIN_DATA)
     assert status_resp.status_code == 200
     assert status_resp.json()["garage_status"] == "closed"
 
 
 def test_retrieve_status():
-    status_resp = client.get("/status", params=LOGIN_DATA)
+    status_resp = client.post("/status", json=LOGIN_DATA)
     assert status_resp.status_code == 200
     assert status_resp.json()["garage_status"] in {"open", "closed"}
-


### PR DESCRIPTION
## Summary
- add pytest to Python dependencies
- include development dependencies in `pyproject.toml`
- create tests for login, open/close, and status endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687624a374a48328a24a19b1cb9058cf