### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Wadeo91/Myq-Open-Door/security/code-scanning/1](https://github.com/Wadeo91/Myq-Open-Door/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily interacts with the repository contents (e.g., checking out code), the minimal required permission is `contents: read`. This ensures that the GITHUB_TOKEN has only read access to the repository contents, reducing the risk of unintended write operations.

The `permissions` block can be added at the root level of the workflow, applying to all jobs, or within the specific job (`build`) to limit its scope. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
